### PR TITLE
Add 'curved' option to type definitions

### DIFF
--- a/react-iconly.d.ts
+++ b/react-iconly.d.ts
@@ -7,7 +7,7 @@ export interface IconProps {
   primaryColor?: Color
   secondaryColor?: Color
   size?: number | 'small' | 'medium' | 'large' | 'xlarge'
-  set?: 'light' | 'bold' | 'two-tone' | 'bulk' | 'broken'
+  set?: 'light' | 'bold' | 'two-tone' | 'bulk' | 'broken' | 'curved'
   stroke?: 'light' | 'regular' | 'bold'
   style?: CSSProperties
   name?: string


### PR DESCRIPTION
While using the package in a typescript based project, 'curved' option can't be used because of type definitions, this pull request fixes it.