### PR TITLE
fix: search input color

### DIFF
--- a/website/src/components/Search/styles.js
+++ b/website/src/components/Search/styles.js
@@ -32,6 +32,7 @@ export const StyledInput = styled.input`
   padding: 10px 0px;
   padding-left: 70px;
   padding-right: 220px;
+  color: #fffff;
   background: ${prop('theme.bg.default')};
   font-size: ${(props) => props.theme.fontSize.lg};
   border-radius: ${(props) => props.theme.borderRadius};


### PR DESCRIPTION
The search field input text colour is black, which is not visible.

Added white color for the search field.
